### PR TITLE
Add picker to paste whole entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,12 @@ Plug 'nvim-telescope/telescope-bibtex.nvim'
 ```
 lua require"telescope".load_extension("bibtex")
 
-:Telescope bibtex
+:Telescope bibtex cite
+
+:Telescope bibtex entry
 ```
+
+**`Telescope bibtex` will still work for now, but becomes deprecated in favor of `Telescope bibtex cite` and will eventually be removed!**
 
 # Configuration
 
@@ -32,9 +36,9 @@ The currently supported formats are:
 
 | Identifier | Result         |
 | ---------- | -------------- |
-| `tex`      | `\cite{entry}` |
-| `md`       | `@entry`       |
-| `plain`    | `entry`        |
+| `tex`      | `\cite{label}` |
+| `md`       | `@label`       |
+| `plain`    | `label`        |
 
 You may add custom formats: `id` is the format identifier, `cite_marker` the format to apply.
 
@@ -64,7 +68,9 @@ require"telescope".setup {
 }
 ```
 
-This produces output like `#entry#`.
+This produces output like `#label#`.
+
+The `entry` picker will always paste the whole entry.
 
 Think of this as defining text before and after the entry and putting a `%s` where the entry should be put.
 

--- a/lua/telescope/_extensions/bibtex.lua
+++ b/lua/telescope/_extensions/bibtex.lua
@@ -112,8 +112,7 @@ local function formatDisplay(entry)
   return vim.trim(display_string:sub(2)), search_string:sub(2)
 end
 
-local function bibtex_picker(opts)
-  opts = opts or {}
+local function setup_picker()
   if not files_initialized then
     initFiles()
     files_initialized = true
@@ -135,6 +134,12 @@ local function bibtex_picker(opts)
       end
     end
   end
+  return results
+end
+
+local function bibtex_picker(opts)
+  opts = opts or {}
+  local results = setup_picker()
   pickers.new(opts, {
     prompt_title = 'Bibtex References',
     finder = finders.new_table {
@@ -188,6 +193,7 @@ return telescope.register_extension {
     search_keys = ext_config.search_keys or search_keys
   end,
   exports = {
-    bibtex = bibtex_picker
+    bibtex = bibtex_picker,
+    bibtex_entry = bibtex_entry_picker
   },
 }

--- a/lua/telescope/_extensions/bibtex.lua
+++ b/lua/telescope/_extensions/bibtex.lua
@@ -211,8 +211,8 @@ local function bibtex_entry_picker(opts)
       actions.select_default:replace(function(_, _)
         local entry = action_state.get_selected_entry().id
         actions.close(prompt_bufnr)
-        vim.api.nvim_put(entry, "", false, false)
-        vim.api.nvim_feedkeys("la", "n", true)
+        vim.api.nvim_put(entry, "", true, true)
+        vim.api.nvim_feedkeys("a", "n", true)
       end)
       return true
     end,


### PR DESCRIPTION
The new picker `Telescope bibtex entry` will display entries as before, but opon selection, it pastes the whole entry to the file

Also rename the standard Picker to `Telescope bibtex cite`.
**`Telescope bibtex` is still available, but now becomes deprecated in favor of the above mentioned.**