### PR TITLE
Change citation format on the fly and provide better default format

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ lua require"telescope".load_extension("bibtex")
 :Telescope bibtex entry
 ```
 
-**`Telescope bibtex` will still work for now, but becomes deprecated in favor of `Telescope bibtex cite` and will eventually be removed!**
+**Calling `:Telescope bibtex` will still work for now, but becomes deprecated in favor of `:Telescope bibtex cite` and will eventually be removed!**
 
 # Configuration
 
@@ -34,11 +34,12 @@ The default search depth for `*.bib` files is 1.
 
 The currently supported formats are:
 
-| Identifier | Result         |
-| ---------- | -------------- |
-| `tex`      | `\cite{label}` |
-| `md`       | `@label`       |
-| `plain`    | `label`        |
+| Identifier        | Result         |
+| ----------        | -------------- |
+| `tex`             | `\cite{label}` |
+| `md` (deprecated) | `@label`       |
+| `markdown`        | `@label`       |
+| `plain`           | `label`        |
 
 You may add custom formats: `id` is the format identifier, `cite_marker` the format to apply.
 
@@ -74,6 +75,15 @@ The `entry` picker will always paste the whole entry.
 
 Think of this as defining text before and after the entry and putting a `%s` where the entry should be put.
 
-If `format` is not defined, the plugin will fall back to `tex` format.
+If `format` is not defined, the plugin will try to find the right format based on the filetype.
+If there is no format for the filetype it will fall back to `plain` format.
+
+To quickly change the format, you can specify it via the options:
+
+```
+:Telescope bibtex cite format=markdown
+```
+
+# Troubleshooting
 
 If the config does not seem to work/apply, check at which point you load the extension. The extension will only be initialized with the right config if it is loaded **after** calling the setup function.

--- a/lua/telescope/_extensions/bibtex.lua
+++ b/lua/telescope/_extensions/bibtex.lua
@@ -139,6 +139,8 @@ end
 
 local function bibtex_picker(opts)
   opts = opts or {}
+  local format = opts.format or user_format
+  local format_string = formats[format] or formats[user_format]
   local results = setup_picker()
   pickers.new(opts, {
     prompt_title = 'Bibtex References',
@@ -168,7 +170,7 @@ local function bibtex_picker(opts)
     sorter = conf.generic_sorter(opts),
     attach_mappings = function(prompt_bufnr)
       actions.select_default:replace(function(_, _)
-        local entry = string.format(formats[user_format], action_state.get_selected_entry().id)
+        local entry = string.format(format_string, action_state.get_selected_entry().id)
         actions.close(prompt_bufnr)
         vim.api.nvim_put({entry}, "", false, false)
         vim.api.nvim_feedkeys("la", "n", true)

--- a/lua/telescope/_extensions/bibtex.lua
+++ b/lua/telescope/_extensions/bibtex.lua
@@ -19,9 +19,11 @@ local depth = 1
 local formats = {}
 formats['tex'] = "\\cite{%s}"
 formats['md'] = "@%s"
+formats['markdown'] = "@%s"
 formats['plain'] = "%s"
-local fallback_format = 'tex'
-local user_format = fallback_format
+local fallback_format = 'plain'
+local use_auto_format = false
+local user_format = ''
 local user_files = {}
 local files_initialized = false
 local files = {}
@@ -139,8 +141,14 @@ end
 
 local function bibtex_picker(opts)
   opts = opts or {}
-  local format = opts.format or user_format
-  local format_string = formats[format] or formats[user_format]
+  local format_string = ''
+  if opts.format ~= nil then
+    format_string = formats[opts.format] or formats[user_format]
+  elseif use_auto_format then
+    format_string = formats[vim.bo.filetype] or formats[fallback_format]
+  else
+    format_string = formats[user_format] or formats[fallback_format]
+  end
   local results = setup_picker()
   pickers.new(opts, {
     prompt_title = 'Bibtex References',
@@ -228,9 +236,11 @@ return telescope.register_extension {
     for _, format in pairs(custom_formats) do
       formats[format.id] = format.cite_marker
     end
-    user_format = ext_config.format or fallback_format
-    if formats[user_format] == nil then
+    if ext_config.format ~= nil and formats[ext_config.format] ~= nil then
+      user_format = ext_config.format
+    else
       user_format = fallback_format
+      use_auto_format = true
     end
     user_files = ext_config.global_files or {}
     search_keys = ext_config.search_keys or search_keys


### PR DESCRIPTION
This MR allows to provide the format directly via the options: 
`:Telescope bibtex cite format=markdown`

It will also use the format based on the detected filetype if no format is specified. otherwise it will fall back to the `plain` format

Closes #24