### PR TITLE
More consistent paste behavior and respect mode

### DIFF
--- a/lua/telescope/_extensions/bibtex.lua
+++ b/lua/telescope/_extensions/bibtex.lua
@@ -181,9 +181,11 @@ local function bibtex_picker(opts)
       actions.select_default:replace(function(_, _)
         local entry = string.format(format_string, action_state.get_selected_entry().id)
         actions.close(prompt_bufnr)
-        vim.api.nvim_put({entry}, "", true, true)
         if mode == "i" then
+          vim.api.nvim_put({entry}, "", false, true)
           vim.api.nvim_feedkeys("a", "n", true)
+        else
+          vim.api.nvim_put({entry}, "", true, true)
         end
       end)
       return true
@@ -225,9 +227,11 @@ local function bibtex_entry_picker(opts)
       actions.select_default:replace(function(_, _)
         local entry = action_state.get_selected_entry().id
         actions.close(prompt_bufnr)
-        vim.api.nvim_put(entry, "", true, true)
         if mode == "i" then
+          vim.api.nvim_put({entry}, "", false, true)
           vim.api.nvim_feedkeys("a", "n", true)
+        else
+          vim.api.nvim_put({entry}, "", true, true)
         end
       end)
       return true

--- a/lua/telescope/_extensions/bibtex.lua
+++ b/lua/telescope/_extensions/bibtex.lua
@@ -141,6 +141,7 @@ end
 
 local function bibtex_picker(opts)
   opts = opts or {}
+  local mode = vim.api.nvim_get_mode().mode
   local format_string = ''
   if opts.format ~= nil then
     format_string = formats[opts.format] or formats[user_format]
@@ -180,8 +181,10 @@ local function bibtex_picker(opts)
       actions.select_default:replace(function(_, _)
         local entry = string.format(format_string, action_state.get_selected_entry().id)
         actions.close(prompt_bufnr)
-        vim.api.nvim_put({entry}, "", false, false)
-        vim.api.nvim_feedkeys("la", "n", true)
+        vim.api.nvim_put({entry}, "", true, true)
+        if mode == "i" then
+          vim.api.nvim_feedkeys("a", "n", true)
+        end
       end)
       return true
     end,
@@ -190,6 +193,7 @@ end
 
 local function bibtex_entry_picker(opts)
   opts = opts or {}
+  local mode = vim.api.nvim_get_mode().mode
   local results = setup_picker()
   pickers.new(opts, {
     prompt_title = 'Bibtex Entries',
@@ -222,7 +226,9 @@ local function bibtex_entry_picker(opts)
         local entry = action_state.get_selected_entry().id
         actions.close(prompt_bufnr)
         vim.api.nvim_put(entry, "", true, true)
-        vim.api.nvim_feedkeys("a", "n", true)
+        if mode == "i" then
+          vim.api.nvim_feedkeys("a", "n", true)
+        end
       end)
       return true
     end,


### PR DESCRIPTION
Paste like `p` instead of `P` when in normal mode and restore normal mode after insertion