### PR TITLE
Markdown subtypes

### DIFF
--- a/lua/telescope/_extensions/bibtex.lua
+++ b/lua/telescope/_extensions/bibtex.lua
@@ -139,17 +139,25 @@ local function setup_picker()
   return results
 end
 
+local function parse_format_string(opts)
+  local format_string = nil
+  if opts.format ~= nil then
+    format_string = formats[opts.format]
+  elseif use_auto_format then
+    if vim.bo.filetype:match('markdown%.%a+') then
+      format_string = formats['markdown']
+    else
+      format_string = formats[vim.bo.filetype]
+    end
+  end
+  format_string = format_string or formats[user_format]
+  return format_string
+end
+
 local function bibtex_picker(opts)
   opts = opts or {}
   local mode = vim.api.nvim_get_mode().mode
-  local format_string = ''
-  if opts.format ~= nil then
-    format_string = formats[opts.format] or formats[user_format]
-  elseif use_auto_format then
-    format_string = formats[vim.bo.filetype] or formats[fallback_format]
-  else
-    format_string = formats[user_format] or formats[fallback_format]
-  end
+  local format_string = parse_format_string(opts)
   local results = setup_picker()
   pickers.new(opts, {
     prompt_title = 'Bibtex References',

--- a/lua/telescope/_extensions/bibtex.lua
+++ b/lua/telescope/_extensions/bibtex.lua
@@ -144,10 +144,9 @@ local function parse_format_string(opts)
   if opts.format ~= nil then
     format_string = formats[opts.format]
   elseif use_auto_format then
-    if vim.bo.filetype:match('markdown%.%a+') then
+    format_string = formats[vim.bo.filetype]
+    if format_string == nil and vim.bo.filetype:match('markdown%.%a+') then
       format_string = formats['markdown']
-    else
-      format_string = formats[vim.bo.filetype]
     end
   end
   format_string = format_string or formats[user_format]


### PR DESCRIPTION
Support markdown subtypes with filetype `markdown.*`  as markdown