### PR TITLE
Fix entry picker

### DIFF
--- a/lua/telescope/_extensions/bibtex.lua
+++ b/lua/telescope/_extensions/bibtex.lua
@@ -235,10 +235,10 @@ local function bibtex_entry_picker(opts)
         local entry = action_state.get_selected_entry().id
         actions.close(prompt_bufnr)
         if mode == "i" then
-          vim.api.nvim_put({entry}, "", false, true)
+          vim.api.nvim_put(entry, "", false, true)
           vim.api.nvim_feedkeys("a", "n", true)
         else
-          vim.api.nvim_put({entry}, "", true, true)
+          vim.api.nvim_put(entry, "", true, true)
         end
       end)
       return true


### PR DESCRIPTION
The entry picker currently seems to crash when used due to a misuse of
`vim.api.nvim_put`

Spawning this error message:
```
E5108: Error executing lua ..lescope-bibtex.nvim/lua/telescope/_extnesions/bibtex.lua:241: Invalid lines (expected array of strings)
stack traceback:
    [C]: in function 'nvim_put'
    ...lescope-bibtex.nvim/lua/telescope/_extensions/bibtex.lua:241: in function 'run_replace_or_original'
```

when selecting an entry in `:Telescope bibtex entry<cr>`

this pull request fixes the misuse so putting the contents of the
entry works as expected.