### PR TITLE
Consolidate cite and entry picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,16 @@ Plug 'nvim-telescope/telescope-bibtex.nvim'
 ```
 lua require"telescope".load_extension("bibtex")
 
-:Telescope bibtex cite
-
-:Telescope bibtex entry
+:Telescope bibtex
 ```
 
-**Calling `:Telescope bibtex` will still work for now, but becomes deprecated in favor of `:Telescope bibtex cite` and will eventually be removed!**
+# Keybindings
+
+| key     | Usage                     |
+|---------|---------------------------|
+| `<cr>`  | Insert the citation label |
+| `<c-e>` | Insert the citation entry |
+
 
 # Configuration
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ lua require"telescope".load_extension("bibtex")
 :Telescope bibtex
 ```
 
-# Keybindings
+# Keybindings (Actions)
 
 | key     | Usage                     |
 |---------|---------------------------|
@@ -41,7 +41,6 @@ The currently supported formats are:
 | Identifier        | Result         |
 | ----------        | -------------- |
 | `tex`             | `\cite{label}` |
-| `md` (deprecated) | `@label`       |
 | `markdown`        | `@label`       |
 | `plain`           | `label`        |
 
@@ -75,7 +74,7 @@ require"telescope".setup {
 
 This produces output like `#label#`.
 
-The `entry` picker will always paste the whole entry.
+The `entry` action will always paste the whole entry.
 
 Think of this as defining text before and after the entry and putting a `%s` where the entry should be put.
 
@@ -85,7 +84,7 @@ If there is no format for the filetype it will fall back to `plain` format.
 To quickly change the format, you can specify it via the options:
 
 ```
-:Telescope bibtex cite format=markdown
+:Telescope bibtex format=markdown
 ```
 
 # Troubleshooting


### PR DESCRIPTION
As the code is currently written every new action gets its own picker. Right now that is only two actions (appending the citation and appending the full entry) however more actions are being requested ( #20 and #30 ). This PR consolidates the picker code so there is only one picker but multiple actions from within it.

Right now it is setup such that the default action is to append the citation and `<c-e>` will append the whole entry.