### PR TITLE
Added context aware bibliography lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ require"telescope".setup {
       -- Context awareness disabled by default
       context = false
       -- Fallback to global/directory .bib files if context not found
-      -- This setting has no affect if context = false
+      -- This setting has no effect if context = false
       context_fallback = true
     },
   }
@@ -117,7 +117,7 @@ require"telescope".setup {
       -- Use context awareness
       context = true,
       -- Use non-contextual behavior if no context found
-      -- This setting has no affect if context = false
+      -- This setting has no effect if context = false
       context_fallback = true,
     },
   }

--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ require"telescope".setup {
 
 If enabled, the plugin will look for context lines in your currently opened file that imply which bibliography file you want to use. See below for common examples based on filetype:
 
-| Filetype              | Context                                    |
-| --------------------- | ------------------------------------------ |
-| `pandoc`, `md`, `rmd` | `bibliography: file_path_with_ext`         |
-| `tex`                 | `\bibliography{relative_file_path_no_ext}` |
+| Filetype              | Context                                                                                     |
+| --------------------- | ------------------------------------------------------------------------------------------- |
+| `pandoc`, `md`, `rmd` | `bibliography: file_path_with_ext`                                                          |
+| `tex`                 | `\bibliography{relative_file_path_no_ext}` or `\addbibresource{relative_file_ath_with_ext}` |
 
 _Note:_ Context awareness ignores the global bibliography files as well as the normal searching in the current directory.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ require"telescope".setup {
       citation_max_auth = 2,
       -- Context awareness disabled by default
       context = false
+      -- Fallback to global/directory .bib files if context not found
+      -- This setting has no affect if context = false
+      context_fallback = true
     },
   }
 }
@@ -103,14 +106,19 @@ _Note:_ Context awareness ignores the global bibliography files as well as the n
 
 Context awareness can be enabled in the setup with `context`.
 
+If a context is not found in the current file, telescope-bibtex can fallback to the non-contextual behavior with `context_fallback`
+
 ```lua
 require"telescope".setup {
   ...
 
   extensions = {
     bibtex = {
-      -- Use context awareness by default
+      -- Use context awareness
       context = true,
+      -- Use non-contextual behavior if no context found
+      -- This setting has no affect if context = false
+      context_fallback = true,
     },
   }
 }

--- a/README.md
+++ b/README.md
@@ -83,9 +83,43 @@ require"telescope".setup {
       -- Max number of authors to write in the formatted citation
       -- following authors will be replaced by "et al."
       citation_max_auth = 2,
+      -- Use context awareness by default
+      context = false
     },
   }
 }
+```
+
+### Context Aware Bibliography File
+
+Two common contexts are included:
+
+| Filetype              | Context                                    |
+| --------------------- | ------------------------------------------ |
+| `pandoc`, `md`, `rmd` | `bibliography: file_path_with_ext`         |
+| `tex`                 | `\bibliography{relative_file_path_no_ext}` |
+
+_Note:_ Context awareness ignores the global bibliography files as well as the normal searching in the current directory.
+
+Context awareness can be enabled by default in the setup with `context`.
+
+```lua
+require"telescope".setup {
+  ...
+
+  extensions = {
+    bibtex = {
+      -- Use context awareness by default
+      context = true,
+    },
+  }
+}
+```
+
+To quickly change the context awareness, you can specify it via the options:
+
+```
+:Telescope bibtex context=false
 ```
 
 ### Label formats

--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ require"telescope".setup {
 
 If enabled, the plugin will look for context lines in your currently opened file that imply which bibliography file you want to use. See below for common examples based on filetype:
 
-| Filetype              | Context                                                                                     |
-| --------------------- | ------------------------------------------------------------------------------------------- |
-| `pandoc`, `md`, `rmd` | `bibliography: file_path_with_ext`                                                          |
-| `tex`                 | `\bibliography{relative_file_path_no_ext}` or `\addbibresource{relative_file_ath_with_ext}` |
+| Filetype              | Context                                                                                      |
+| --------------------- | -------------------------------------------------------------------------------------------- |
+| `pandoc`, `md`, `rmd` | `bibliography: file_path_with_ext`                                                           |
+| `tex`                 | `\bibliography{relative_file_path_no_ext}` or `\addbibresource{relative_file_path_with_ext}` |
 
 _Note:_ Context awareness ignores the global bibliography files as well as the normal searching in the current directory.
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ require"telescope".setup {
       -- Max number of authors to write in the formatted citation
       -- following authors will be replaced by "et al."
       citation_max_auth = 2,
-      -- Use context awareness by default
+      -- Context awareness disabled by default
       context = false
     },
   }
@@ -92,7 +92,7 @@ require"telescope".setup {
 
 ### Context Aware Bibliography File
 
-Two common contexts are included:
+If enabled, the plugin will look for context lines in your currently opened file that imply which bibliography file you want to use. See below for common examples based on filetype:
 
 | Filetype              | Context                                    |
 | --------------------- | ------------------------------------------ |
@@ -101,7 +101,7 @@ Two common contexts are included:
 
 _Note:_ Context awareness ignores the global bibliography files as well as the normal searching in the current directory.
 
-Context awareness can be enabled by default in the setup with `context`.
+Context awareness can be enabled in the setup with `context`.
 
 ```lua
 require"telescope".setup {

--- a/lua/telescope/_extensions/bibtex.lua
+++ b/lua/telescope/_extensions/bibtex.lua
@@ -50,13 +50,9 @@ end
 local function getContextBibFiles()
   local found_files = {}
   context_files = {}
-  if
-    vim.o.filetype == 'pandoc'
-    or vim.o.filetype == 'markdown'
-    or vim.o.filetype == 'rmd'
-  then
+  if utils.isPandocFile() then
     found_files = utils.parsePandoc()
-  elseif vim.o.filetype == 'tex' then
+  elseif utils.isLatexFile() then
     found_files = utils.parseLatex()
   end
   for _, file in pairs(found_files) do

--- a/lua/telescope/_extensions/bibtex/utils.lua
+++ b/lua/telescope/_extensions/bibtex/utils.lua
@@ -104,6 +104,7 @@ end
 M.bufferLines = function()
   return vim.api.nvim_buf_get_lines(0, 0, -1, false)
 end
+
 M.extendRelativePath = function(rel_path)
   local base = vim.fn.expand('%:p:h')
   local path_sep = vim.loop.os_uname().sysname == 'Windows' and '\\' or '/'
@@ -113,11 +114,12 @@ end
 M.trimWhitespace = function(str)
   return str:match('^%s*(.-)%s*$')
 end
+
 M.parseLatex = function()
   local files = {}
   for _, line in ipairs(M.bufferLines()) do
-    local bibs = line:match('\\bibliography{(%g+)}')
-    local bibresource = line:match('\\addbibresource{(%g+)}')
+    local bibs = line:match('^[^%%]*\\bibliography{(%g+)}')
+    local bibresource = line:match('^[^%%]*\\addbibresource{(%g+)}')
     if bibs then
       for _, bib in ipairs(M.split_str(bibs, ',')) do
         bib = M.extendRelativePath(bib .. '.bib')

--- a/lua/telescope/_extensions/bibtex/utils.lua
+++ b/lua/telescope/_extensions/bibtex/utils.lua
@@ -115,6 +115,10 @@ M.trimWhitespace = function(str)
   return str:match('^%s*(.-)%s*$')
 end
 
+M.isLatexFile = function()
+  return vim.o.filetype == 'tex'
+end
+
 M.parseLatex = function()
   local files = {}
   for _, line in ipairs(M.bufferLines()) do
@@ -135,6 +139,12 @@ M.parseLatex = function()
     end
   end
   return files
+end
+
+M.isPandocFile = function()
+  return vim.o.filetype == 'pandoc'
+    or vim.o.filetype == 'markdown'
+    or vim.o.filetype == 'rmd'
 end
 
 M.parsePandoc = function()


### PR DESCRIPTION
I love this plugin and wanted it to be able to contextually figure out where the bibliography file is and only open the bibliography that is relevant to the file that I am currently editing. This aims to do just that. Works great if I am writing a markdown or LaTeX file that references a bibliography in another folder.

Let me know if there is anything I need to change in functionality/documentation/formatting since this is my first contribution to the project.