### PR TITLE
re-introduce field picker to insert bibtext field values

### DIFF
--- a/lua/telescope-bibtex/actions.lua
+++ b/lua/telescope-bibtex/actions.lua
@@ -1,6 +1,10 @@
 local actions = require('telescope.actions')
 local utils = require('telescope-bibtex.utils')
 local action_state = require('telescope.actions.state')
+local pickers = require("telescope.pickers")
+local finders = require('telescope.finders')
+local previewers = require('telescope.previewers')
+local conf = require('telescope.config').values
 
 return {
   key_append = function(format_string)
@@ -42,6 +46,53 @@ return {
       else
         vim.api.nvim_paste(citation, true, -1)
       end
+    end
+  end,
+
+  field_append = function()
+    return function(prompt_bufnr)
+      local entry = action_state.get_selected_entry().id.content
+      actions.close(prompt_bufnr)
+      local parsed = utils.parse_entry(entry)
+      pickers.new(opts, {
+        prompt_title = "Bibtex fields",
+        sorter = conf.generic_sorter(opts),
+        finder = finders.new_table{
+          results = utils.get_bibkeys(parsed),
+        },
+        previewer = previewers.new_buffer_previewer({
+          define_preview = function(self, bib_entry, status)
+            vim.api.nvim_buf_set_lines(
+              self.state.bufnr,
+              0,
+              -1,
+              true,
+              {parsed[bib_entry[1]]}
+            )
+            vim.api.nvim_win_set_option(
+              status.preview_win,
+              'wrap',
+              true
+            )
+          end,
+        }),
+        attach_mappings = function(prompt_bufnr)
+          actions.select_default:replace(
+            function()
+              actions.close(prompt_bufnr)
+              local selection = action_state.get_selected_entry()
+              local mode = vim.api.nvim_get_mode().mode
+              if mode == 'i' then
+                vim.api.nvim_put({parsed[selection[1]]}, '', false, true)
+                vim.api.nvim_feedkeys('a', 'n', true)
+              else
+                vim.api.nvim_put({parsed[selection[1]]}, '', true, true)
+              end
+            end
+          )
+          return true
+        end
+      }):find()
     end
   end
 }

--- a/lua/telescope-bibtex/utils.lua
+++ b/lua/telescope-bibtex/utils.lua
@@ -719,4 +719,13 @@ M.format_citation = function(entry, template, opts)
   return M.format_template(parsed, template)
 end
 
+-- Make a dict of parsed bibtex fields
+M.get_bibkeys = function(parsed_entry)
+  local bibkeys={}
+  for key,_ in pairs(parsed_entry) do
+    table.insert(bibkeys, key)
+  end
+  return bibkeys
+end
+
 return M

--- a/lua/telescope/_extensions/bibtex.lua
+++ b/lua/telescope/_extensions/bibtex.lua
@@ -47,6 +47,7 @@ local keymaps = {
   i = {
     ["<C-e>"] = bibtex_actions.entry_append,
     ["<C-c>"] = bibtex_actions.citation_append(citation_format),
+    ["<C-f>"] = bibtex_actions.field_append(citation_format),
   }
 }
 


### PR DESCRIPTION
I noticed that the bibtex field entry function introduced in #59 was removed by #70 (e45f108).
However, the mapping is still available according to the README. I've re-introduced this function and have tried to follow the new refactored code, but since it spawns an additional previewer I may have written it in a more complex way than necessary. I couldn't figure out how to use the table made by `utils.parse_entry` as the result for the field previewer.